### PR TITLE
Rättade datum m.m.

### DIFF
--- a/public/content/data/fortroendevalda.csv
+++ b/public/content/data/fortroendevalda.csv
@@ -1,5 +1,5 @@
 Nämnd id,Mail,Namn,Klass,Mandatperiod
-CtyreLsen,ctyrelsen@cl-sektionen.se,,,2023.01.01 - 2023.12.31
+CtyreLsen,ctyrelsen@cl-sektionen.se,,,2023-01-01 – 2023-12-31
 Ordförande,ordf@cl-sektionen.se,Gustav Heldt,CL20,
 Vice ordförande tillika sekreterare,vordf@cl-sektionen.se,Andrea Donné,CL21,
 Kassör,ekonomi@cl-sektionen.se,Matilda Algotsson,CL21,
@@ -7,63 +7,63 @@ Ledamot för Utbildningsfrågor,utbildning@cl-sektionen.se,Alexander Jansson,CL1
 Ledamot för Näringslivsfrågor och Kommunikation,naringsliv@cl-sektionen.se,Emelie Selinder,CL19,
 Ledamot för Studiesociala- och JML-frågor,studiesocialt@cl-sektionen.se,Fanny Enocksson,CL19,
 ,,,,
-Studienamnden,studienamnden@cl-sektionen.se,,,2023.01.01 - 2023.12.31
+Studienamnden,studienamnden@cl-sektionen.se,,,2023-01-01 – 2023-12-31
 Ordförande,sno@cl-sektionen.se,Moa Wettby,CL21,
 Programansvarig student,pas@cl-sektionen.se,Viktor Hallberg,CL22,
 Utbildningsbevakare,ubbe@cl-sektionen.se,Svante Holgersson,CL20,
 Utbytesansvarig,utbyte@cl-sektionen.se,Vakant,,
 ,,,,
-Naringslivsnamnden,naringslivsnamnden@cl-sektionen.se,,,2023.01.01 - 2023.12.31
+Naringslivsnamnden,naringslivsnamnden@cl-sektionen.se,,,2023-01-01 – 2023-12-31
 Ordförande,ordf.naringsliv@cl-sektionen.se,Frida Sundberg,CL16,
 Vice ordförande,vice.naringsliv@cl-sektionen.se,Viktor Uhlgren,CL22,
 PR-ansvarig,pr@cl-sektionen.se,Tuva Egman,CL20,
 Webbunderhållare,webbunderhallare@cl-sektionen.se,Jesper Svensson,CL21,
 Webbutvecklare,webbutvecklare@cl-sektionen.se,Armin Baymani,CL19,
 ,,,,
-JML-namnden,jml-namnden@cl-sektionen.se,,,2023.01.01 - 2023.12.31
+JML-namnden,jml-namnden@cl-sektionen.se,,,2023-01-01 – 2023-12-31
 Ordförande,jml@cl-sektionen.se,Maja Jansson,CL22,
 Vice ordförande tillika studerandeskyddsombud,skyddsombud@cl-sektionen.se,Lea Martinelle,CL20,
 ,,,,
-Aktivitetsnamnden,aktivitetsnamnden@cl-sektionen.se,,,2023.01.01 - 2023.12.31
+Aktivitetsnamnden,aktivitetsnamnden@cl-sektionen.se,,,2023-01-01 – 2023-12-31
 Ordförande,aktivitetsnamnden@cl-sektionen.se,Rasmus Harders,CL22,
 Vice ordförande,vice.aktivitetsnamnden@cl-sektionen.se,Aron Johansson,CL22,
 ,,,,
-Lokalnamnden,,,,2023.01.01 - 2023.12.31
+Lokalnamnden,,,,2023-01-01 – 2023-12-31
 Ordförande,lokalnamnden@cl-sektionen.se,Anders Wallenthin,CL20,
 ,,,,
-Mottagningsnamnden,mottagningsnamnden@cl-sektionen.se,,,2023.01.01 - 2023.12.31
+Mottagningsnamnden,mottagningsnamnden@cl-sektionen.se,,,2023-01-01 – 2023-12-31
 Mottagningsansvarig,mottagningen@cl-sektionen.se,Oscar Ekström,CL20,
 Vice mottagningsansvarig,vice.mottagningen@cl-sektionen.se,Emma Östling,CL19,
 Ekonomiskt ansvarig för mottagningen,ekonomi.mottagningen@cl-sektionen.se,Joar Söderman,CL21,
 ,,,,
-CLW,clw@cl-sektionen.se,,,2022.05.01 - 2023.04.30
+CLW,clw@cl-sektionen.se,,,2023-05-01 – 2024-04-30
 Klubbmästare - CL,clw@cl-sektionen.se,Fabian Olesen,CL22,
 Klubbmästare - W,klubbmastare@w-sektionen.se,Anton Tystrand,W20,
 Ekonomiskt ansvarig,ekonomi.clw@cl-sektionen.se,Amanda Helgesson,W22,
 ,,,,
-Valberedningen,val@cl-sektionen.se,,,2022.05.01 - 2023.04.30
+Valberedningen,val@cl-sektionen.se,,,2023-05-01 – 2024-04-30
 Femmans representant även sammankallande,,Anton Sundberg,CL19,
 Fyrans representant,,Elias Keytuli,CL19,
 Treans representant,,Vera Roos,CL21,
 Tvåans representant,,Elin Ebbers,CL22,
 Ettans representant,,Vakant,,
 ,,,,
-Revisorer,revisor@cl-sektionen.se,,,2023.01.01 - 2023.12.31
+Revisorer,revisor@cl-sektionen.se,,,2023-01-01 – 2023-12-31
 Revisor,revisor1@cl-sektionen.se,Erik Åman,CL19,
 Revisor,revisor2@cl-sektionen.se,Emil Rapp,CL20,
 ,,,,
-Fanborg,fanborg@cl-sektionen.se,,,2023.02.01 - 2024.01.31
+Fanborg,fanborg@cl-sektionen.se,,,2023-02-01 – 2024-01-31
 Fanbärare,,Armin Baymani,CL19,
 Vice fanbärare,,Fanny Enocksson,CL19,
 Fanbärare suppleant,,Ellen Olsson,CL19,
 Fanbärare suppleant,,Jesper Svensson,CL21,
 ,,,,
-KF,kf@cl-sektionen.se,,,2022.07.01 - 2023.06.31
+KF,kf@cl-sektionen.se,,,2023-07-01 – 2024-06-30
 Ledamot,,Frida Andersson,CL20,
-Förste suppleant,,Gustav Heldt,CL20,
-Andre suppleant,,Emil Rapp,CL20,
+Suppleant,,Gustav Heldt,CL20,
+Reserv,,Emil Rapp,CL20,
 ,,,,
-Enskilda,,,,2023.01.01 - 2023.12.31
+Enskilda,,,,2023-01-01 – 2023-12-31
 Talman 👩‍⚖️,talman@cl-sektionen.se,Veronica Vilbern,CL17,
 Försäljningsansvarig 🛒,forsaljning@cl-sektionen.se,"Mikael ""Moppe"" Lundkvist",CL19,
 Idrottsansvarig ⚽,idrott@cl-sektionen.se,Astrid Joseph,CL22,


### PR DESCRIPTION
Rättade några datum med fel år.

Passar också på att ändra till format YYYY-MM-DD enligt ISO 8601.

Det finns inte förste och andre suppleant i KF, utan vi har en ledamot och en suppleant som har rätt att representera oss. Emil kan bara bli aktuell om vi anmäler till THS att antingen Gustav eller Frida avgått och i så fall blir han suppleant. Jag skrev "reserv", men den term som står i THS reglemente är egentligen "resterande kandidater".